### PR TITLE
Workaround unable to make root fs in image during backup

### DIFF
--- a/functions/milliways-image-backup
+++ b/functions/milliways-image-backup
@@ -194,6 +194,11 @@ ROOTUSED=$(((${DFKSIZE} - ${DFKFREE}) * 1024))
 IRFSMIN=$(((${ROOTUSED} + (${ADDBLK} * ${BLKSIZE}) + (${ONEMB} - 1)) / ${ONEMB}))
 IRFSMAX=$(((${ROOTSIZE} + (${ONEMB} - 1)) / ${ONEMB}))
 
+# Workaround unable to make ext4 fs in img if blksize is 512
+if [ "${BLKSIZE}" = "512" ]; then
+  ROOT_DEV="1024"
+fi
+
 img="$1"
 
 if [ -z "$img" ];then

--- a/functions/milliways-image-backup
+++ b/functions/milliways-image-backup
@@ -196,7 +196,7 @@ IRFSMAX=$(((${ROOTSIZE} + (${ONEMB} - 1)) / ${ONEMB}))
 
 # Workaround unable to make ext4 fs in img if blksize is 512
 if [ "${BLKSIZE}" = "512" ]; then
-  BLKSIZE="1024"
+  BLKSIZE="4096"
 fi
 
 img="$1"

--- a/functions/milliways-image-backup
+++ b/functions/milliways-image-backup
@@ -196,7 +196,7 @@ IRFSMAX=$(((${ROOTSIZE} + (${ONEMB} - 1)) / ${ONEMB}))
 
 # Workaround unable to make ext4 fs in img if blksize is 512
 if [ "${BLKSIZE}" = "512" ]; then
-  ROOT_DEV="1024"
+  BLKSIZE="1024"
 fi
 
 img="$1"


### PR DESCRIPTION
Fixes this error:
https://cdn.discordapp.com/attachments/839507782088130570/845443367717306368/unknown.png

I am testing it right now, will respond back after my backup completes if the backup works or not. I am a filesystem noob so no idea if it'll work or not or if it's best practice.